### PR TITLE
Fix other metrics AlreadyRegisteredErrors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/sample_and_watermark_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +36,8 @@ const (
 	ddtOffsetCentiPeriods = 50
 	numIterations         = 100
 )
+
+var once sync.Once
 
 /* TestSampler does a rough behavioral test of the sampling in a
    SampleAndWatermarkHistograms.  The test creates one and exercises
@@ -61,7 +64,9 @@ func TestSampler(t *testing.T) {
 	saw := gen.Generate(0, 1, []string{})
 	regs := gen.metrics()
 	for _, reg := range regs {
-		legacyregistry.MustRegister(reg)
+		once.Do(func() {
+			legacyregistry.MustRegister(reg)
+		})
 	}
 	// `dt` is the admitted cumulative difference in fake time
 	// since the start of the test.  "admitted" means this is


### PR DESCRIPTION
Append changes to kubernetes#105809
```
make test KUBE_RACE=-race KUBE_TIMEOUT=--timeout=600s GOFLAGS=-count=1 WHAT=./staging/src/k8s.io/apiserver/pkg/util/flowcontrol/metrics/
```
